### PR TITLE
Hashicorp Vault support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,13 @@ env:
     - TOX_ENV=flake8
 
 before_install:
+    - mkdir $HOME/bin
     - export JYTHON_URL='http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.7.0/jython-installer-2.7.0.jar'
     - if [ "$TOX_ENV" == "jython" ]; then wget $JYTHON_URL -O jython_installer.jar; java -jar jython_installer.jar -s -d $HOME/jython; fi
+    - if [ `uname -m` == "x86_64" ] || [ `uname -m` == "amd64" ]; then export ARCH="amd64"; else export ARCH="386"; fi
+    - export PLATFORM=`uname -s | tr '[:upper:]' '[:lower:]'`
+    - export VAULT_URL="https://releases.hashicorp.com/vault/0.6.1/vault_0.6.1_${PLATFORM}_${ARCH}.zip"
+    - wget $VAULT_URL -O vault.zip; unzip -o vault.zip; mv vault $HOME/bin; rm vault.zip
 
 install:
     - pip install tox python-coveralls

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -5,11 +5,7 @@ Supported backends
 
 The following backends are supported as of version |version|:
 
-* commandline arguments (using argparse)
-* environment variables
-* ConfigObj files
-* JSON files
-* YAML files (using PyYAML)
+.. contents :: :local:
 
 backend interface
 -----------------

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -63,3 +63,12 @@ Files in YAML format are supported. This backend is only enabled if `omniconf.ya
 
 .. autoclass :: omniconf.backends.yaml.YamlBackend
    :members:
+
+Hashicorp Vault
+---------------
+
+Hashicorp's Vault is supported by using its API. This backend requires several configuration keys to be defined during
+setup, see the documentation below for details.
+
+.. autoclass :: omniconf.backends.vault.VaultBackend
+   :members:

--- a/omniconf/backends/__init__.py
+++ b/omniconf/backends/__init__.py
@@ -34,6 +34,12 @@ try:
 except ImportError:  # pragma: nocover
     pass
 
+try:
+    from omniconf.backends.vault import VaultBackend
+    available_backends.append(VaultBackend)
+except ImportError:  # pragma: nocover
+    pass
+
 available_backends += [JsonBackend, EnvBackend, ArgparseBackend]
 autodetection_backends = [EnvBackend, ArgparseBackend]
 

--- a/omniconf/backends/vault.py
+++ b/omniconf/backends/vault.py
@@ -120,7 +120,10 @@ class VaultBackend(ConfigBackend):
         data_key = parts.pop()
         path = join_key_parts("/", parts)
 
-        node = self.client.read(path)
+        try:
+            node = self.client.read(path)
+        except hvac.exceptions.Forbidden:
+            raise KeyError("No access to Vault data node at {0}".format(path))
         if not node:
             raise KeyError("No Vault data node at {0}".format(path))
         return node['data'][data_key]

--- a/omniconf/backends/vault.py
+++ b/omniconf/backends/vault.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2016 Cyso < development [at] cyso . com >
+#
+# This file is part of omniconf, a.k.a. python-omniconf .
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see
+# <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import
+from omniconf.backends.generic import ConfigBackend
+from omniconf.exceptions import InvalidBackendConfiguration
+from omniconf.keys import join_key, join_key_parts
+from omniconf.setting import Setting
+import hvac
+
+
+class VaultBackend(ConfigBackend):
+    """
+    Uses Hashicorp's Vault as a backend, and allows values in it to
+    be retrieved using dotted keys.
+    """
+
+    def __init__(self, conf=None, prefix=None, url=None, auth=None, credentials=None):
+        if not prefix:
+            prefix = ""
+        self.prefix = prefix
+
+        if auth == "token":
+            self.client = hvac.Client(url=url, token=credentials)
+
+        elif auth == "client_cert":
+            self.client = hvac.Client(url=url, cert=credentials)
+            self.client.auth_tls()
+
+        elif auth in ("userpass", "ldap", "appid", "approle"):
+            identifier, secret = credentials
+            self.client = hvac.Client(url=url)
+            if auth == "userpass":
+                self.client.auth_userpass(identifier, secret)
+            elif auth == "ldap":
+                self.client.auth_ldap(identifier, secret)
+            elif auth == "appid":
+                self.client.auth_app_id(identifier, secret)
+            else:
+                self.client.auth_approle(identifier, secret)
+
+        else:
+            raise InvalidBackendConfiguration("Invalid authentication mechanism selected for Vault backend.")
+
+        if not self.client.is_authenticated():
+            raise InvalidBackendConfiguration("Vault backend is not authenticated")
+
+    @classmethod
+    def _config_keys(cls, autoconfigure_prefix):
+        return {
+            "url": join_key(autoconfigure_prefix, "vault", "url"),
+            "token": join_key(autoconfigure_prefix, "vault", "auth", "token"),
+            "tls_cert": join_key(autoconfigure_prefix, "vault", "auth", "tls", "cert", "filename"),
+            "tls_key": join_key(autoconfigure_prefix, "vault", "auth", "tls", "key", "filename"),
+            "username": join_key(autoconfigure_prefix, "vault", "auth", "userpass", "username"),
+            "password": join_key(autoconfigure_prefix, "vault", "auth", "userpass", "password"),
+            "ldap_user": join_key(autoconfigure_prefix, "vault", "auth", "ldap", "username"),
+            "ldap_pass": join_key(autoconfigure_prefix, "vault", "auth", "ldap", "password"),
+            "app_id": join_key(autoconfigure_prefix, "vault", "auth", "appid", "app_id"),
+            "user_id": join_key(autoconfigure_prefix, "vault", "auth", "appid", "user_id"),
+            "app_role": join_key(autoconfigure_prefix, "vault", "auth", "approle", "role_id"),
+            "app_secret": join_key(autoconfigure_prefix, "vault", "auth", "approle", "secret_id")
+        }
+
+    @classmethod
+    def autodetect_settings(cls, autoconfigure_prefix):
+        settings = []
+        for name, key in cls._config_keys(autoconfigure_prefix).iteritems():
+            if name == "url":
+                settings.append(Setting(key=key, _type=str, required=False, default="http://localhost:8200"))
+            else:
+                settings.append(Setting(key=key, _type=str, required=False))
+        return settings
+
+    @classmethod
+    def autoconfigure(cls, conf, autoconfigure_prefix):
+        keys = cls._config_keys(autoconfigure_prefix)
+        url = conf.get(keys['url'])
+
+        if conf.has(keys['token']):
+            return VaultBackend(url=url, auth="token", credentials=conf.get(keys['token']))
+
+        elif conf.has(keys['tls_cert']) and conf.has(keys['tls_key']):
+            return VaultBackend(url=url, auth="client_cert", credentials=(conf.get(keys['tls_cert']), conf.get(keys['tls_key'])))
+
+        elif conf.has(keys['username']) and conf.has(keys['password']):
+            return VaultBackend(url=url, auth="userpass", credentials=(conf.get(keys['username']), conf.get(keys['password'])))
+
+        elif conf.has(keys['ldap_user']) and conf.has(keys['ldap_pass']):
+            return VaultBackend(url=url, auth="ldap", credentials=(conf.get(keys['ldap_user']), conf.get(keys['ldap_pass'])))
+
+        elif conf.has(keys['app_id']) and conf.has(keys['user_id']):
+            return VaultBackend(url=url, auth="appid", credentials=(conf.get(keys['app_id']), conf.get(keys['user_id'])))
+
+        elif conf.has(keys['app_role']) and conf.has(keys['app_secret']):
+            return VaultBackend(url=url, auth="approle", credentials=(conf.get(keys['app_role']), conf.get(keys['app_secret'])))
+
+        return None
+
+    def get_value(self, key):
+        parts = key.split(".")
+        if self.prefix:
+            parts.insert(0, self.prefix)
+
+        data_key = parts.pop()
+        path = join_key_parts("/", parts)
+
+        node = self.client.read(path)
+        if not node:
+            raise KeyError("No Vault data node at {0}".format(path))
+        return node['data'][data_key]

--- a/omniconf/backends/vault.py
+++ b/omniconf/backends/vault.py
@@ -31,9 +31,11 @@ class VaultBackend(ConfigBackend):
     """
 
     def __init__(self, conf=None, prefix=None, url=None, auth=None,
-                 credentials=None):
+                 credentials=None, base_path=None):
         if not prefix:
             prefix = ""
+        if base_path:
+            prefix = base_path
         self.prefix = prefix
 
         if auth == "token":
@@ -67,6 +69,7 @@ class VaultBackend(ConfigBackend):
     def _config_keys(cls, autoconfigure_prefix):
         return {
             "url": join_key(autoconfigure_prefix, "vault", "url"),
+            "base_path": join_key(autoconfigure_prefix, "vault", "base_path"),
             "token": join_key(autoconfigure_prefix, "vault", "auth", "token"),
             "tls_cert": join_key(autoconfigure_prefix, "vault", "auth", "tls",
                                  "cert", "filename"),

--- a/omniconf/backends/vault.py
+++ b/omniconf/backends/vault.py
@@ -93,7 +93,7 @@ class VaultBackend(ConfigBackend):
     @classmethod
     def autodetect_settings(cls, autoconfigure_prefix):
         settings = []
-        for name, key in cls._config_keys(autoconfigure_prefix).iteritems():
+        for name, key in cls._config_keys(autoconfigure_prefix).items():
             if name == "url":
                 settings.append(Setting(key=key, _type=str, required=False,
                                         default="http://localhost:8200"))

--- a/omniconf/backends/vault.py
+++ b/omniconf/backends/vault.py
@@ -30,7 +30,8 @@ class VaultBackend(ConfigBackend):
     be retrieved using dotted keys.
     """
 
-    def __init__(self, conf=None, prefix=None, url=None, auth=None, credentials=None):
+    def __init__(self, conf=None, prefix=None, url=None, auth=None,
+                 credentials=None):
         if not prefix:
             prefix = ""
         self.prefix = prefix
@@ -55,26 +56,38 @@ class VaultBackend(ConfigBackend):
                 self.client.auth_approle(identifier, secret)
 
         else:
-            raise InvalidBackendConfiguration("Invalid authentication mechanism selected for Vault backend.")
+            raise InvalidBackendConfiguration(
+                "Invalid authentication mechanism selected for Vault backend.")
 
         if not self.client.is_authenticated():
-            raise InvalidBackendConfiguration("Vault backend is not authenticated")
+            raise InvalidBackendConfiguration(
+                "Vault backend is not authenticated")
 
     @classmethod
     def _config_keys(cls, autoconfigure_prefix):
         return {
             "url": join_key(autoconfigure_prefix, "vault", "url"),
             "token": join_key(autoconfigure_prefix, "vault", "auth", "token"),
-            "tls_cert": join_key(autoconfigure_prefix, "vault", "auth", "tls", "cert", "filename"),
-            "tls_key": join_key(autoconfigure_prefix, "vault", "auth", "tls", "key", "filename"),
-            "username": join_key(autoconfigure_prefix, "vault", "auth", "userpass", "username"),
-            "password": join_key(autoconfigure_prefix, "vault", "auth", "userpass", "password"),
-            "ldap_user": join_key(autoconfigure_prefix, "vault", "auth", "ldap", "username"),
-            "ldap_pass": join_key(autoconfigure_prefix, "vault", "auth", "ldap", "password"),
-            "app_id": join_key(autoconfigure_prefix, "vault", "auth", "appid", "app_id"),
-            "user_id": join_key(autoconfigure_prefix, "vault", "auth", "appid", "user_id"),
-            "app_role": join_key(autoconfigure_prefix, "vault", "auth", "approle", "role_id"),
-            "app_secret": join_key(autoconfigure_prefix, "vault", "auth", "approle", "secret_id")
+            "tls_cert": join_key(autoconfigure_prefix, "vault", "auth", "tls",
+                                 "cert", "filename"),
+            "tls_key": join_key(autoconfigure_prefix, "vault", "auth", "tls",
+                                "key", "filename"),
+            "username": join_key(autoconfigure_prefix, "vault", "auth",
+                                 "userpass", "username"),
+            "password": join_key(autoconfigure_prefix, "vault", "auth",
+                                 "userpass", "password"),
+            "ldap_user": join_key(autoconfigure_prefix, "vault", "auth",
+                                  "ldap", "username"),
+            "ldap_pass": join_key(autoconfigure_prefix, "vault", "auth",
+                                  "ldap", "password"),
+            "app_id": join_key(autoconfigure_prefix, "vault", "auth", "appid",
+                               "app_id"),
+            "user_id": join_key(autoconfigure_prefix, "vault", "auth", "appid",
+                                "user_id"),
+            "app_role": join_key(autoconfigure_prefix, "vault", "auth",
+                                 "approle", "role_id"),
+            "app_secret": join_key(autoconfigure_prefix, "vault", "auth",
+                                   "approle", "secret_id")
         }
 
     @classmethod
@@ -82,7 +95,8 @@ class VaultBackend(ConfigBackend):
         settings = []
         for name, key in cls._config_keys(autoconfigure_prefix).iteritems():
             if name == "url":
-                settings.append(Setting(key=key, _type=str, required=False, default="http://localhost:8200"))
+                settings.append(Setting(key=key, _type=str, required=False,
+                                        default="http://localhost:8200"))
             else:
                 settings.append(Setting(key=key, _type=str, required=False))
         return settings
@@ -93,22 +107,33 @@ class VaultBackend(ConfigBackend):
         url = conf.get(keys['url'])
 
         if conf.has(keys['token']):
-            return VaultBackend(url=url, auth="token", credentials=conf.get(keys['token']))
+            return VaultBackend(url=url, auth="token",
+                                credentials=conf.get(keys['token']))
 
         elif conf.has(keys['tls_cert']) and conf.has(keys['tls_key']):
-            return VaultBackend(url=url, auth="client_cert", credentials=(conf.get(keys['tls_cert']), conf.get(keys['tls_key'])))
+            return VaultBackend(url=url, auth="client_cert",
+                                credentials=(conf.get(keys['tls_cert']),
+                                             conf.get(keys['tls_key'])))
 
         elif conf.has(keys['username']) and conf.has(keys['password']):
-            return VaultBackend(url=url, auth="userpass", credentials=(conf.get(keys['username']), conf.get(keys['password'])))
+            return VaultBackend(url=url, auth="userpass",
+                                credentials=(conf.get(keys['username']),
+                                             conf.get(keys['password'])))
 
         elif conf.has(keys['ldap_user']) and conf.has(keys['ldap_pass']):
-            return VaultBackend(url=url, auth="ldap", credentials=(conf.get(keys['ldap_user']), conf.get(keys['ldap_pass'])))
+            return VaultBackend(url=url, auth="ldap",
+                                credentials=(conf.get(keys['ldap_user']),
+                                             conf.get(keys['ldap_pass'])))
 
         elif conf.has(keys['app_id']) and conf.has(keys['user_id']):
-            return VaultBackend(url=url, auth="appid", credentials=(conf.get(keys['app_id']), conf.get(keys['user_id'])))
+            return VaultBackend(url=url, auth="appid",
+                                credentials=(conf.get(keys['app_id']),
+                                             conf.get(keys['user_id'])))
 
         elif conf.has(keys['app_role']) and conf.has(keys['app_secret']):
-            return VaultBackend(url=url, auth="approle", credentials=(conf.get(keys['app_role']), conf.get(keys['app_secret'])))
+            return VaultBackend(url=url, auth="approle",
+                                credentials=(conf.get(keys['app_role']),
+                                             conf.get(keys['app_secret'])))
 
         return None
 

--- a/omniconf/exceptions.py
+++ b/omniconf/exceptions.py
@@ -29,3 +29,10 @@ class UnconfiguredSettingError(Exception):
     Trying to retrieve a value which has not been configured yet.
     """
     pass
+
+
+class InvalidBackendConfiguration(Exception):
+    """
+    Trying to configure a backend with invalid configuration.
+    """
+    pass

--- a/omniconf/keys.py
+++ b/omniconf/keys.py
@@ -22,4 +22,12 @@ def join_key(*args):
     Convenience builder for dotted keys. Will join all True-ish positional
     arguments by dots.
     """
-    return ".".join([arg for arg in args if arg])
+    return join_key_parts(separator=".", parts=args)
+
+
+def join_key_parts(separator, parts):
+    """
+    Convenience builder for keys and paths. Will join all True-ish parts
+    using the given separator.
+    """
+    return separator.join([part for part in parts if part])

--- a/omniconf/tests/backends/test_argparse.py
+++ b/omniconf/tests/backends/test_argparse.py
@@ -16,6 +16,7 @@
 # License along with this library. If not, see
 # <http://www.gnu.org/licenses/>.
 
+from omniconf.backends import available_backends
 from omniconf.backends.argparse import ArgparseBackend
 from mock import patch
 import nose.tools
@@ -42,6 +43,10 @@ CONFIGS = [
     ("section", None, KeyError),
     ("unknown", None, KeyError)
 ]
+
+
+def test_argparse_backend_in_available_backends():
+    nose.tools.assert_in(ArgparseBackend, available_backends)
 
 
 def test_argparse_backend_autoconfigure():

--- a/omniconf/tests/backends/test_configobj.py
+++ b/omniconf/tests/backends/test_configobj.py
@@ -22,7 +22,7 @@ from omniconf.config import ConfigRegistry
 from omniconf.setting import SettingRegistry
 try:
     from StringIO import StringIO
-except ImportError:
+except ImportError:  # pragma: nocover
     from io import StringIO
 import nose.tools
 

--- a/omniconf/tests/backends/test_configobj.py
+++ b/omniconf/tests/backends/test_configobj.py
@@ -16,6 +16,7 @@
 # License along with this library. If not, see
 # <http://www.gnu.org/licenses/>.
 
+from omniconf.backends import available_backends
 from omniconf.backends.configobj import ConfigObjBackend
 from omniconf.config import ConfigRegistry
 from omniconf.setting import SettingRegistry
@@ -43,6 +44,10 @@ CONFIGS = [
     ("section", {"bar": "baz", "subsection": {"baz": "foo"}}, None),
     ("unknown", None, KeyError)
 ]
+
+
+def test_configobj_backend_in_available_backends():
+    nose.tools.assert_in(ConfigObjBackend, available_backends)
 
 
 def test_configobj_backend_autoconfigure():

--- a/omniconf/tests/backends/test_env.py
+++ b/omniconf/tests/backends/test_env.py
@@ -16,6 +16,7 @@
 # License along with this library. If not, see
 # <http://www.gnu.org/licenses/>.
 
+from omniconf.backends import available_backends
 from omniconf.backends.env import EnvBackend
 from mock import patch
 import nose.tools
@@ -61,6 +62,10 @@ CONFIGS = [
     ("section", None, KeyError),
     ("unknown", None, KeyError)
 ]
+
+
+def test_env_backend_in_available_backends():
+    nose.tools.assert_in(EnvBackend, available_backends)
 
 
 def test_env_backend_autoconfigure():

--- a/omniconf/tests/backends/test_json.py
+++ b/omniconf/tests/backends/test_json.py
@@ -16,6 +16,7 @@
 # License along with this library. If not, see
 # <http://www.gnu.org/licenses/>.
 
+from omniconf.backends import available_backends
 from omniconf.backends.json import JsonBackend
 from omniconf.config import ConfigRegistry
 from omniconf.setting import SettingRegistry
@@ -42,6 +43,10 @@ CONFIGS = [
     ("section", {"bar": "baz", "subsection": {"baz": "foo"}}, None),
     ("unknown", None, KeyError)
 ]
+
+
+def test_json_backend_in_available_backends():
+    nose.tools.assert_in(JsonBackend, available_backends)
 
 
 @patch("json.loads")

--- a/omniconf/tests/backends/test_vault.py
+++ b/omniconf/tests/backends/test_vault.py
@@ -70,7 +70,8 @@ class TestVaultBackend(unittest.TestCase):
             f.flush()
 
             cls.root_client = hvac.Client(url="http://localhost:18200")
-            cls.manager = ServerManager(config_path=f.name, client=cls.root_client)
+            cls.manager = ServerManager(config_path=f.name,
+                                        client=cls.root_client)
             cls.manager.start()
 
             try:
@@ -79,8 +80,10 @@ class TestVaultBackend(unittest.TestCase):
                 cls.root_client.token = cls.manager.root_token
                 cls.root_client.set_policy("deny", DENY_POLICY)
                 cls.root_client.set_policy("normal", NORMAL_POLICY)
-                cls.deny_token = cls.root_client.create_token(id="DENY", policies=["deny"])['auth']['client_token']
-                cls.normal_token = cls.root_client.create_token(id="NORMAL", policies=["normal"])['auth']['client_token']
+                cls.deny_token = cls.root_client.create_token(
+                    id="DENY", policies=["deny"])['auth']['client_token']
+                cls.normal_token = cls.root_client.create_token(
+                    id="NORMAL", policies=["normal"])['auth']['client_token']
             except:
                 cls.manager.stop()
                 raise

--- a/omniconf/tests/backends/test_vault.py
+++ b/omniconf/tests/backends/test_vault.py
@@ -139,6 +139,29 @@ class TestVaultBackend(unittest.TestCase):
         self.vault.prefix = "secret"
         self.assertEqual(self.vault.get_value("foo.bar"), "baz")
 
+    def test_vault_backend_without_prefix_or_basepath(self):
+        vault = VaultBackend(url="http://localhost:18200",
+                             auth="token", credentials=self.normal_token)
+        self.assertEqual(vault.prefix, "")
+
+    def test_vault_backend_with_prefix_no_basepath(self):
+        vault = VaultBackend(url="http://localhost:18200",
+                             auth="token", credentials=self.normal_token,
+                             prefix="foo")
+        self.assertEqual(vault.prefix, "foo")
+
+    def test_vault_backend_with_basepath_no_prefix(self):
+        vault = VaultBackend(url="http://localhost:18200",
+                             auth="token", credentials=self.normal_token,
+                             base_path="base")
+        self.assertEqual(vault.prefix, "base")
+
+    def test_vault_backend_with_prefix_and_basepath(self):
+        vault = VaultBackend(url="http://localhost:18200",
+                             auth="token", credentials=self.normal_token,
+                             prefix="foo", base_path="base")
+        self.assertEqual(vault.prefix, "base")
+
 
 def _setup_vault_autoconfig(prefix):
     settings = SettingRegistry()

--- a/omniconf/tests/backends/test_vault.py
+++ b/omniconf/tests/backends/test_vault.py
@@ -19,6 +19,7 @@
 import hvac
 from hvac.tests.util import ServerManager
 from mock import patch, ANY
+from omniconf.backends import available_backends
 from omniconf.backends.vault import VaultBackend
 from omniconf.config import ConfigRegistry
 from omniconf.exceptions import InvalidBackendConfiguration
@@ -60,6 +61,10 @@ DENY_TOKEN = {
     "id": "DENY",
     "policies": ["deny"]
 }
+
+
+def test_vault_backend_in_available_backends():
+    nose.tools.assert_in(VaultBackend, available_backends)
 
 
 class TestVaultBackend(unittest.TestCase):

--- a/omniconf/tests/backends/test_vault.py
+++ b/omniconf/tests/backends/test_vault.py
@@ -80,7 +80,7 @@ class TestVaultBackend(unittest.TestCase):
                                         client=cls.root_client)
             try:
                 cls.manager.start()
-            except OSError:
+            except OSError:  # pragma: nocover
                 raise SkipTest("vault binary not present in PATH.")
 
             try:

--- a/omniconf/tests/backends/test_vault.py
+++ b/omniconf/tests/backends/test_vault.py
@@ -98,7 +98,6 @@ class TestVaultBackend(unittest.TestCase):
         cls.manager.stop()
 
     def setUp(self):
-        self.assertTrue(self.root_client.is_authenticated)
         self.vault = VaultBackend(url="http://localhost:18200",
                                   auth="token", credentials=self.normal_token)
         self.keys = []

--- a/omniconf/tests/backends/test_vault.py
+++ b/omniconf/tests/backends/test_vault.py
@@ -89,7 +89,7 @@ class TestVaultBackend(unittest.TestCase):
                     id="DENY", policies=["deny"])['auth']['client_token']
                 cls.normal_token = cls.root_client.create_token(
                     id="NORMAL", policies=["normal"])['auth']['client_token']
-            except:
+            except:  # pragma: nocover
                 cls.manager.stop()
                 raise
 

--- a/omniconf/tests/backends/test_vault.py
+++ b/omniconf/tests/backends/test_vault.py
@@ -19,6 +19,7 @@
 import hvac
 from hvac.tests.util import ServerManager
 from mock import patch, ANY
+from nose.plugins.skip import SkipTest
 from omniconf.backends import available_backends
 from omniconf.backends.vault import VaultBackend
 from omniconf.config import ConfigRegistry
@@ -77,7 +78,10 @@ class TestVaultBackend(unittest.TestCase):
             cls.root_client = hvac.Client(url="http://localhost:18200")
             cls.manager = ServerManager(config_path=f.name,
                                         client=cls.root_client)
-            cls.manager.start()
+            try:
+                cls.manager.start()
+            except OSError:
+                raise SkipTest("vault binary not present in PATH.")
 
             try:
                 cls.manager.initialize()

--- a/omniconf/tests/backends/test_vault.py
+++ b/omniconf/tests/backends/test_vault.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2016 Cyso < development [at] cyso . com >
+#
+# This file is part of omniconf, a.k.a. python-omniconf .
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see
+# <http://www.gnu.org/licenses/>.
+
+import hvac
+from hvac.tests.util import ServerManager
+from omniconf.backends.vault import VaultBackend
+from tempfile import NamedTemporaryFile
+import unittest
+
+VAULT_CONFIG = """
+backend "inmem" {
+}
+
+listener "tcp" {
+address = "127.0.0.1:18200"
+tls_disable = 1
+}
+
+disable_mlock = true
+"""
+
+NORMAL_POLICY = """
+path "secret/*" {
+    capabilities = ["read"]
+}
+"""
+
+DENY_POLICY = """
+path "secret/*" {
+    capabilities = ["deny"]
+}
+"""
+
+NORMAL_TOKEN = {
+    "id": "NORMAL",
+    "policies": ["normal"]
+}
+
+DENY_TOKEN = {
+    "id": "DENY",
+    "policies": ["deny"]
+}
+
+
+class TestVault(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        with NamedTemporaryFile() as f:
+            f.write(VAULT_CONFIG.encode('utf-8'))
+            f.flush()
+
+            cls.root_client = hvac.Client(url="http://localhost:18200")
+            cls.manager = ServerManager(config_path=f.name, client=cls.root_client)
+            cls.manager.start()
+
+            try:
+                cls.manager.initialize()
+                cls.manager.unseal()
+                cls.root_client.token = cls.manager.root_token
+                cls.root_client.set_policy("deny", DENY_POLICY)
+                cls.root_client.set_policy("normal", NORMAL_POLICY)
+                cls.deny_token = cls.root_client.create_token(id="DENY", policies=["deny"])['auth']['client_token']
+                cls.normal_token = cls.root_client.create_token(id="NORMAL", policies=["normal"])['auth']['client_token']
+            except:
+                cls.manager.stop()
+                raise
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.manager.stop()
+
+    def setUp(self):
+        self.assertTrue(self.root_client.is_authenticated)
+        self.vault = VaultBackend(url="http://localhost:18200",
+                                  auth="token", credentials=self.normal_token)
+        self.keys = []
+
+    def tearDown(self):
+        self.clean_keys()
+
+    def write_key(self, key, **kwargs):
+        self.root_client.write(key, **kwargs)
+        self.keys.append(key)
+
+    def clean_keys(self):
+        for key in self.keys:
+            self.root_client.delete(key)
+        self.keys = []
+
+    def test_vault_backend_get(self):
+        self.write_key("secret/foo", bar="baz")
+        self.assertEqual(self.vault.get_value("secret.foo.bar"), "baz")
+
+    def test_vault_backend_get_no_node(self):
+        with self.assertRaises(KeyError):
+            self.vault.get_value("secret.foo.bar")
+
+    def test_vault_backend_get_no_value(self):
+        self.write_key("secret/foo", bar="baz")
+        with self.assertRaises(KeyError):
+            self.vault.get_value("secret.foo.baz")
+
+    def test_vault_backend_get_no_access(self):
+        self.write_key("secret/foo", bar="baz")
+        with self.assertRaises(KeyError):
+            self.vault.client.token = self.deny_token
+            self.vault.get_value("secret.foo.bar")
+
+    def test_vault_backend_get_with_prefix(self):
+        self.write_key("secret/foo", bar="baz")
+        self.vault.prefix = "secret"
+        self.assertEqual(self.vault.get_value("foo.bar"), "baz")

--- a/omniconf/tests/backends/test_yaml.py
+++ b/omniconf/tests/backends/test_yaml.py
@@ -16,6 +16,7 @@
 # License along with this library. If not, see
 # <http://www.gnu.org/licenses/>.
 
+from omniconf.backends import available_backends
 from omniconf.backends.yaml import YamlBackend
 from omniconf.config import ConfigRegistry
 from omniconf.setting import SettingRegistry
@@ -39,6 +40,10 @@ CONFIGS = [
     ("section", {"bar": "baz", "subsection": {"baz": "foo"}}, None),
     ("unknown", None, KeyError)
 ]
+
+
+def test_yaml_backend_in_available_backends():
+    nose.tools.assert_in(YamlBackend, available_backends)
 
 
 @patch("yaml.load")

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,3 +1,4 @@
 Sphinx
 configobj
 PyYAML
+hvac

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,9 @@ setup(
         "configobj": [
             "configobj"
         ],
+        "vault": [
+            "hvac"
+        ],
         "yaml": [
             "PyYAML"
         ]

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
     nose
     mock
     hvac
+    semantic_version
 commands =
     nosetests
     /bin/mv .coverage reports/coverage-{envname}.dat
@@ -23,6 +24,7 @@ deps =
     nose
     mock
     hvac
+    semantic_version
 commands =
     nosetests
     /bin/mv nosetests.xml reports/nosetests-{envname}.xml

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     coverage
     nose
     mock
+    hvac
 commands =
     nosetests
     /bin/mv .coverage reports/coverage-{envname}.dat
@@ -21,6 +22,7 @@ deps =
     coverage
     nose
     mock
+    hvac
 commands =
     nosetests
     /bin/mv nosetests.xml reports/nosetests-{envname}.xml
@@ -41,9 +43,10 @@ commands =
 
 [testenv:flake8]
 deps =
-	configobj
-	PyYAML
-	flake8
+    configobj
+    PyYAML
+    hvac
+    flake8
 commands = flake8 omniconf
 
 [testenv:sphinx]


### PR DESCRIPTION
Adds support for Hashicorp's Vault.

Vault can be used to securely store secrets, which can only be read by certain clients based on ACLs. See the full documentation here: https://www.vaultproject.io/docs/index.html .