### PR TITLE
Fix YAML file loading

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -60,6 +60,7 @@ YAML files
 ----------
 
 Files in YAML format are supported. This backend is only enabled if `omniconf.yaml.filename` is specified during setup.
+All YAML documents in the file are consumed.
 
 .. autoclass :: omniconf.backends.yaml.YamlBackend
    :members:

--- a/omniconf/backends/yaml.py
+++ b/omniconf/backends/yaml.py
@@ -41,5 +41,6 @@ class YamlBackend(ConfigBackend):
     def autoconfigure(cls, conf, autoconfigure_prefix):
         filename_key = join_key(autoconfigure_prefix, "yaml", "filename")
         if conf.has(filename_key):
-            return YamlBackend(conf=conf.get(filename_key))
+            with open(conf.get(filename_key)) as config_file:
+                return YamlBackend(conf=config_file)
         return None

--- a/omniconf/backends/yaml.py
+++ b/omniconf/backends/yaml.py
@@ -30,7 +30,11 @@ class YamlBackend(ConfigBackend):
     """
 
     def __init__(self, conf):
-        super(YamlBackend, self).__init__(yaml.load(conf))
+        loaded_conf = {}
+        for doc in yaml.load_all(conf):
+            loaded_conf.update(doc)
+
+        super(YamlBackend, self).__init__(loaded_conf)
 
     @classmethod
     def autodetect_settings(cls, autoconfigure_prefix):

--- a/omniconf/tests/backends/test_yaml.py
+++ b/omniconf/tests/backends/test_yaml.py
@@ -29,6 +29,9 @@ section:
   bar: baz
   subsection:
     baz: foo
+---
+bar:
+  sub: bar-sub-value
 """
 
 CONFIGS = [
@@ -37,14 +40,15 @@ CONFIGS = [
     ("section.subsection.baz", "foo", None),
     ("", None, KeyError),
     ("section", {"bar": "baz", "subsection": {"baz": "foo"}}, None),
-    ("unknown", None, KeyError)
+    ("unknown", None, KeyError),
+    ("bar.sub", "bar-sub-value", None)
 ]
 
 
 @patch("yaml.load")
 def test_yaml_backend_autoconfigure(yaml_load):
     from omniconf.backends import yaml as omniconf_backend_yaml
-    omniconf_backend_yaml.open = mock_open(read_data='foo');
+    omniconf_backend_yaml.open = mock_open(read_data=YAML_FILE);
     prefix = "testconf"
     settings = SettingRegistry()
     settings.add(YamlBackend.autodetect_settings(prefix)[0])

--- a/omniconf/tests/backends/test_yaml.py
+++ b/omniconf/tests/backends/test_yaml.py
@@ -19,7 +19,7 @@
 from omniconf.backends.yaml import YamlBackend
 from omniconf.config import ConfigRegistry
 from omniconf.setting import SettingRegistry
-from mock import patch
+from mock import patch, mock_open, Mock
 import nose.tools
 
 YAML_FILE = """
@@ -42,7 +42,9 @@ CONFIGS = [
 
 
 @patch("yaml.load")
-def test_yaml_backend_autoconfigure(mock):
+def test_yaml_backend_autoconfigure(yaml_load):
+    from omniconf.backends import yaml as omniconf_backend_yaml
+    omniconf_backend_yaml.open = mock_open(read_data='foo');
     prefix = "testconf"
     settings = SettingRegistry()
     settings.add(YamlBackend.autodetect_settings(prefix)[0])

--- a/omniconf/tests/backends/test_yaml.py
+++ b/omniconf/tests/backends/test_yaml.py
@@ -19,7 +19,7 @@
 from omniconf.backends.yaml import YamlBackend
 from omniconf.config import ConfigRegistry
 from omniconf.setting import SettingRegistry
-from mock import patch, mock_open, Mock
+from mock import patch, mock_open
 import nose.tools
 
 YAML_FILE = """
@@ -46,9 +46,9 @@ CONFIGS = [
 
 
 @patch("yaml.load")
-def test_yaml_backend_autoconfigure(yaml_load):
+def test_yaml_backend_autoconfigure(mock):
     from omniconf.backends import yaml as omniconf_backend_yaml
-    omniconf_backend_yaml.open = mock_open(read_data=YAML_FILE);
+    omniconf_backend_yaml.open = mock_open(read_data=YAML_FILE)
     prefix = "testconf"
     settings = SettingRegistry()
     settings.add(YamlBackend.autodetect_settings(prefix)[0])


### PR DESCRIPTION
The yaml autoconfigure function now reads the file and works with the file's content. Also, multiple YAML documents in one file are now supported. 