### PR TITLE
Feature/use travis trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
     - export PLATFORM=`uname -s | tr '[:upper:]' '[:lower:]'`
     - export VAULT_URL="https://releases.hashicorp.com/vault/0.6.1/vault_0.6.1_${PLATFORM}_${ARCH}.zip"
     - wget $VAULT_URL -O vault.zip; unzip -o vault.zip; mv vault $HOME/bin; rm vault.zip
+    - curl -vv -tlsv1 -o vault.zip $VAULT_URL; unzip -o vault.zip; mv vault $HOME/bin; rm vault.zip
 
 install:
     - pip install tox python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: false
 language: python
 addons:
@@ -5,6 +6,9 @@ addons:
         sources:
             - deadsnakes
         packages:
+            - ca-certificates
+            - curl
+            - openssl
             - python3.5
             - python3.5-dev
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ before_install:
     - if [ `uname -m` == "x86_64" ] || [ `uname -m` == "amd64" ]; then export ARCH="amd64"; else export ARCH="386"; fi
     - export PLATFORM=`uname -s | tr '[:upper:]' '[:lower:]'`
     - export VAULT_URL="https://releases.hashicorp.com/vault/0.6.1/vault_0.6.1_${PLATFORM}_${ARCH}.zip"
-    - wget $VAULT_URL -O vault.zip; unzip -o vault.zip; mv vault $HOME/bin; rm vault.zip
     - curl -vv -tlsv1 -o vault.zip $VAULT_URL; unzip -o vault.zip; mv vault $HOME/bin; rm vault.zip
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,14 @@ addons:
             - ca-certificates
             - curl
             - openssl
+            - pypy
+            - pypy-dev
+            - python2.7
+            - python2.7-dev
+            - python3.3
+            - python3.3-dev
+            - python3.4
+            - python3.4-dev
             - python3.5
             - python3.5-dev
 env:

--- a/omniconf/config.py
+++ b/omniconf/config.py
@@ -123,6 +123,7 @@ class ConfigRegistry(object):
                 raise UnconfiguredSettingError("No value was configured for "
                                                "{0}".format(setting.key))
 
+
 DEFAULT_REGISTRY = ConfigRegistry()
 """
 Global :class:`.ConfigRegistry` which will be used when no specific

--- a/omniconf/setting.py
+++ b/omniconf/setting.py
@@ -70,6 +70,7 @@ class SettingRegistry(object):
         """
         del self.registry[self._key(setting)]
 
+
 DEFAULT_REGISTRY = SettingRegistry()
 """
 Global :class:`.SettingRegistry` which will be used when no specific

--- a/omniconf/tests/test_config.py
+++ b/omniconf/tests/test_config.py
@@ -154,6 +154,7 @@ class TestConfigMethod(unittest.TestCase):
         DEFAULT_REGISTRY.unset("foo")
         SETTING_REGISTRY.remove(_setting)
 
+
 VALUE_TESTS = [
     # Normal values
     ("foobar", "foobar", str, None),


### PR DESCRIPTION
Switch to the Travis Ubuntu Trusty image, because Precise is very old and crusty by now.