### PR TITLE
Fix Jython tests by pinning an older version of requests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ deps =
     configobj
     PyYAML
     nose
-    requests!=2.12.*
+    requests<2.12.0
     rednose
     mock
     hvac


### PR DESCRIPTION
Newer versions (>=2.13.0) of requests introduce a new issue
with Jython. Also see:

https://github.com/kennethreitz/requests/issues/3992