### PR TITLE
Move metadata and requirements to setup.cfg, and enable pbr

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,48 @@
+[metadata]
+name = omniconf
+author = Nick Douma
+author-email = n.douma@nekoconeko.nl
+summary = A Python library that makes configuring your application independent from your configuration backend.
+description-file = README.rst
+home-page = https://github.com/cyso/omniconf
+license = LGPLv3
+classifier =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    Intended Audience :: Information Technology
+    Intended Audience :: System Administrators
+    License :: OSI Approved :: GNU Lesser General Public License v3 or later (LGPLv3+)
+    Operating System :: POSIX
+    Operating System :: POSIX :: Linux
+    Operating System :: Unix
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: Jython
+    Programming Language :: Python :: Implementation :: PyPy
+    Topic :: Software Development :: Libraries :: Python Modules
+    Topic :: Software Development :: User Interfaces
+    Topic :: System :: Installation/Setup
+    Topic :: Utilities
+keywords =
+    omniconf
+    config
+    configuration
+
+[extras]
+configobj =
+    configobj
+vault =
+    requests<2.12.0:platform.python_implementation=='Jython'
+    hvac
+yaml =
+    PyYAML
+
 [nosetests]
 verbosity=2
 nocapture=1

--- a/setup.py
+++ b/setup.py
@@ -19,66 +19,9 @@
 # <http://www.gnu.org/licenses/>.
 
 
-from setuptools import setup, find_packages
-
-DESCRIPTION = "A Python library that makes configuring your application "\
-              "independent from your configuration backend."
-LONG_DESCRIPTION = open('README.rst').read()
-NAME = "omniconf"
-VERSION = "1.1.1"
-BUILD = "1064891"
-
+from setuptools import setup
 
 setup(
-    name=NAME,
-    version=VERSION,
-    description=DESCRIPTION,
-    long_description=LONG_DESCRIPTION,
-    license="LGPL3",
-    author="Nick Douma",
-    author_email="n.douma@nekoconeko.nl",
-    url="https://github.com/cyso/omniconf",
-    packages=find_packages(),
-    data_files=[('', ['README.rst'])],
-    install_requires=[],
-    extras_require={
-        "configobj": [
-            "configobj"
-        ],
-        "vault": [
-            "hvac"
-        ],
-        "yaml": [
-            "PyYAML"
-        ]
-    },
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Information Technology",
-        "Intended Audience :: System Administrators",
-        "License :: OSI Approved :: "
-            "GNU Lesser General Public License v3 or later (LGPLv3+)",
-        "Operating System :: POSIX",
-        "Operating System :: POSIX :: Linux",
-        "Operating System :: Unix",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: "
-            "Implementation :: CPython",
-        "Programming Language :: Python :: "
-            "Implementation :: Jython",
-        "Programming Language :: Python :: "
-            "Implementation :: PyPy",
-        "Topic :: Software Development :: "
-            "Libraries :: Python Modules",
-        "Topic :: Software Development :: User Interfaces",
-        "Topic :: System :: Installation/Setup",
-        "Topic :: Utilities"
-    ]
+    setup_requires=['pbr>=1.9', 'setuptools>=17.1'],
+    pbr=True,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,12 @@ envlist = setup,py27,py33,py34,py35,py36,pypy,jython,coverage,sphinx
 deps =
     configobj
     PyYAML
+    hvac
+
     coverage
     nose
     rednose
     mock
-    hvac
     semantic_version
 commands =
     nosetests --rednose
@@ -21,11 +22,12 @@ commands =
 deps =
     configobj
     PyYAML
-    nose
     requests<2.12.0
+    hvac
+
+    nose
     rednose
     mock
-    hvac
     semantic_version
 commands =
     nosetests --rednose
@@ -50,6 +52,7 @@ deps =
     configobj
     PyYAML
     hvac
+
     flake8
     collective.checkdocs
     pygments


### PR DESCRIPTION
Let's use pbr for omniconf. This allows use to leverage all the tools that come with pbr, and we'll never have to think about creating proper version numbers again. All dependencies are moved to requirements.txt, and only need to be specified there.