### PR TITLE
Fix cli flags parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
     - if [ `uname -m` == "x86_64" ] || [ `uname -m` == "amd64" ]; then export ARCH="amd64"; else export ARCH="386"; fi
     - export PLATFORM=`uname -s | tr '[:upper:]' '[:lower:]'`
     - export VAULT_URL="https://releases.hashicorp.com/vault/0.6.1/vault_0.6.1_${PLATFORM}_${ARCH}.zip"
-    - mkdir $HOME/bin
+    - mkdir -p $HOME/bin
 
 install:
     - curl -fSL -tlsv1 -o vault.zip $VAULT_URL && unzip -o vault.zip && mv vault $HOME/bin && rm vault.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,9 @@ install:
     - if [ -n "$JYTHON_VERSION" ]; then curl -fSL -o jython_installer.jar $JYTHON_URL && echo "$JYTHON_SHASUM *jython_installer.jar" | shasum -c - && java -jar jython_installer.jar -s -d $HOME/jython && rm jython_installer.jar; fi
 
 before_script:
-    - pip install -U pip setuptools tox python-coveralls
+    - pip install -U setuptools
+    - pip install -U pip tox python-coveralls
+    - pip freeze --all
     - if [ -n "$JYTHON_VERSION" ]; then export PATH=$HOME/jython/bin:$PATH; fi
     - tox -e setup
 

--- a/omniconf/backends/argparse.py
+++ b/omniconf/backends/argparse.py
@@ -74,8 +74,8 @@ class ArgparseBackend(ConfigBackend):
 
     def get_values(self, settings):
         """
-        Retrieves the value for the given :class:`.Setting`. Keys are
-        converted as follows:
+        Process the given list :class:`.Setting` objects, and retrieve the
+        values. Keys are converted as follows:
 
         * Dots are replaced by dashes (-).
         * The key is lowercased.

--- a/omniconf/backends/argparse.py
+++ b/omniconf/backends/argparse.py
@@ -66,10 +66,13 @@ class ArgparseBackend(ConfigBackend):
                 return parser.add_argument(argument, action="store_false")
             else:
                 return parser.add_argument(argument, action="store_true")
-        else:
-            return parser.add_argument(argument)
+        return parser.add_argument(argument)
 
     def get_value(self, setting):
+        raise NotImplementedError("get_value is not implemented for "
+                                  "ArgparseBackend, use get_values instead.")
+
+    def get_values(self, settings):
         """
         Retrieves the value for the given :class:`.Setting`. Keys are
         converted as follows:
@@ -92,26 +95,31 @@ class ArgparseBackend(ConfigBackend):
         * Settings with `_type=bool`, and where the default value is False will
           be specified as an argparse argument with `action=store_true`.
         """
-        _key, _prop, _arg = format_argparse_key(setting.key, self.prefix)
-
-        if not _key:
-            raise KeyError("Empty keys are not allowed")
         parser = argparse.ArgumentParser(add_help=False)
 
         # Disable forced output from argparse we don't want to display
         parser.print_usage = suppress_output
         parser._print_message = suppress_output
 
-        ArgparseBackend.add_argument(parser, _arg, setting)
+        for setting in settings:
+            if not setting.key:
+                raise KeyError("Empty keys are not allowed")
+            _key, _prop, _arg = format_argparse_key(setting.key, self.prefix)
+            ArgparseBackend.add_argument(parser, _arg, setting)
 
         try:
             args = parser.parse_known_args(args=ARGPARSE_SOURCE)[0]
         except SystemExit:
             raise KeyError("Error parsing value for {0}".format(setting.key))
 
-        if getattr(args, _prop) is None:
-            raise KeyError("{0} has no value".format(setting.key))
-        return getattr(args, _prop)
+        arguments = vars(args)
+        values = []
+        for setting in settings:
+            _, _prop, _ = format_argparse_key(setting.key, self.prefix)
+            if _prop in arguments:
+                values.append((setting, arguments[_prop]))
+
+        return values
 
 
 class ArgparseUsageInformation(object):

--- a/omniconf/backends/generic.py
+++ b/omniconf/backends/generic.py
@@ -59,5 +59,8 @@ class ConfigBackend(object):
         """
         values = []
         for setting in settings:
-            values.append((setting, self.get_value(setting)))
+            try:
+                values.append((setting, self.get_value(setting)))
+            except KeyError:
+                pass
         return values

--- a/omniconf/backends/generic.py
+++ b/omniconf/backends/generic.py
@@ -51,3 +51,13 @@ class ConfigBackend(object):
         for _key in setting.key.split("."):
             section = section[_key]
         return section
+
+    def get_values(self, settings):
+        """
+        Retrieves a list of :class:`.Setting`s all at once. Values are returned
+        as a list of tuples containing the :class:`.Setting` and value.
+        """
+        values = []
+        for setting in settings:
+            values.append((setting, self.get_value(setting)))
+        return values

--- a/omniconf/config.py
+++ b/omniconf/config.py
@@ -114,8 +114,6 @@ class ConfigRegistry(object):
                     continue
                 try:
                     self.set(setting.key, value)
-                except KeyError:
-                    pass
                 except ValueError as ve:
                     raise ValueError("An invalid value was specified for "
                                      "{0}: {1}".format(setting.key, ve))

--- a/omniconf/config.py
+++ b/omniconf/config.py
@@ -16,6 +16,7 @@
 # License along with this library. If not, see
 # <http://www.gnu.org/licenses/>.
 
+from collections import OrderedDict
 from omniconf.exceptions import UnknownSettingError, UnconfiguredSettingError
 from omniconf.setting import DEFAULT_REGISTRY as SETTING_REGISTRY
 import ast
@@ -41,7 +42,7 @@ class ConfigRegistry(object):
         self.clear()
 
     def clear(self):
-        self.registry = {}
+        self.registry = OrderedDict()
 
     def set(self, key, value):
         """
@@ -107,21 +108,26 @@ class ConfigRegistry(object):
         was attempting to load, and no value found and no default was set, an
         UnconfiguredSettingError is raised.
         """
-        for setting in self.settings.list():
-            if setting.key in self.registry:
-                continue
-            for backend in backends:
+        for backend in backends:
+            for setting, value in backend.get_values(self.settings.list()):
+                if setting.key in self.registry:
+                    continue
                 try:
-                    self.set(setting.key, backend.get_value(setting))
+                    self.set(setting.key, value)
                 except KeyError:
                     pass
                 except ValueError as ve:
                     raise ValueError("An invalid value was specified for "
-                                     "{0}: {1}".format(setting.key, str(ve)))
+                                     "{0}: {1}".format(setting.key, ve))
 
+        missing_settings = []
+        for setting in self.settings.list():
             if not self.has(setting.key) and setting.required:
-                raise UnconfiguredSettingError("No value was configured for "
-                                               "{0}".format(setting.key))
+                missing_settings.append(setting.key)
+        if missing_settings:
+            raise UnconfiguredSettingError("No value was configured for: {0}"
+                                           .format(", "
+                                                   .join(missing_settings)))
 
 
 DEFAULT_REGISTRY = ConfigRegistry()

--- a/omniconf/setting.py
+++ b/omniconf/setting.py
@@ -16,13 +16,15 @@
 # License along with this library. If not, see
 # <http://www.gnu.org/licenses/>.
 
+from collections import OrderedDict
+
 
 class SettingRegistry(object):
     """
     A registry of defined :class:`Setting` objects.
     """
     def __init__(self):
-        self.registry = {}
+        self.registry = OrderedDict()
 
     def _key(self, setting):
         if isinstance(setting, str):
@@ -31,7 +33,7 @@ class SettingRegistry(object):
             return setting.key
 
     def clear(self):
-        self.registry = {}
+        self.registry = OrderedDict()
 
     def add(self, setting):
         """

--- a/omniconf/tests/backends/test_argparse.py
+++ b/omniconf/tests/backends/test_argparse.py
@@ -99,13 +99,14 @@ def test_mixed_flags_and_settings():
     MIXED_ARGS = [
         "--verbose", "--loud",
         "--foo-bar", "baz",
-        "--bar", "baz"
+        "--bar", "buzz"
     ]
 
     settings = SettingRegistry()
     settings.add(Setting(key="verbose", _type=bool, default=False))
     settings.add(Setting(key="loud", _type=bool, default=True))
     settings.add(Setting(key="foo.bar", _type=str))
+    settings.add(Setting(key="bar", _type=str))
     configs = ConfigRegistry(setting_registry=settings)
 
     with patch('omniconf.backends.argparse.ARGPARSE_SOURCE', MIXED_ARGS):
@@ -115,3 +116,4 @@ def test_mixed_flags_and_settings():
         nose.tools.assert_true(configs.get("verbose"))
         nose.tools.assert_false(configs.get("loud"))
         nose.tools.assert_equal(configs.get("foo.bar"), "baz")
+        nose.tools.assert_equal(configs.get("bar"), "buzz")

--- a/omniconf/tests/backends/test_argparse.py
+++ b/omniconf/tests/backends/test_argparse.py
@@ -24,7 +24,6 @@ from mock import patch
 import nose.tools
 
 ARGS_FILE = [
-    "script.py",
     "--foo", "bar",
     "--section-bar", "baz",
     "--section-subsection-baz", "foo",
@@ -35,7 +34,6 @@ ARGS_FILE = [
 ]
 
 PREFIX_ARGS_FILE = [
-    "script.py",
     "--prefix-foo", "bar",
     "--prefix-section-bar", "baz",
     "--prefix-section-subsection-baz", "foo",
@@ -50,10 +48,8 @@ CONFIGS = [
     (Setting(key="foo", _type=str), "bar", None),
     (Setting(key="section.bar", _type=str), "baz", None),
     (Setting(key="section.subsection.baz", _type=str), "foo", None),
-    (Setting(key="", _type=str), None, KeyError),
-    (Setting(key="section", _type=str), None, KeyError),
-    (Setting(key="unknown", _type=str), None, KeyError),
 
+    (Setting(key="", _type=str), None, KeyError),
     (Setting(key="missing.value", _type=str), None, KeyError),
 
     (Setting(key="bool.normal", _type=bool), "1", None),
@@ -77,33 +73,39 @@ def test_argparse_backend_autoconfigure():
 
 
 def test_argparse_backend_get_value():
+    with nose.tools.assert_raises(NotImplementedError):
+        backend = ArgparseBackend()
+        backend.get_value(None)
+
+
+def test_argparse_backend_get_values():
     for setting, value, sideeffect in CONFIGS:
-        yield _test_get_value, setting, value, sideeffect, None
-        yield _test_get_value, setting, value, sideeffect, 'prefix'
+        yield _test_get_values, setting, value, sideeffect, None
+        yield _test_get_values, setting, value, sideeffect, 'prefix'
 
 
-def _test_get_value(setting, value, sideeffect, prefix):
+def _test_get_values(setting, value, sideeffect, prefix):
     with patch('omniconf.backends.argparse.ARGPARSE_SOURCE',
                ARGS_FILE if not prefix else PREFIX_ARGS_FILE):
         backend = ArgparseBackend(prefix=prefix)
         if sideeffect:
             with nose.tools.assert_raises(sideeffect):
-                backend.get_value(setting)
+                backend.get_values([setting])
         else:
-            nose.tools.assert_equal(backend.get_value(setting), value)
+            nose.tools.assert_equal(backend.get_values([setting])[0][1], value)
 
 
 def test_mixed_flags_and_settings():
     MIXED_ARGS = [
-        "script.py",
-        "--verbose",
-        "--foo bar",
-        "--bar baz"
+        "--verbose", "--loud",
+        "--foo-bar", "baz",
+        "--bar", "baz"
     ]
 
     settings = SettingRegistry()
     settings.add(Setting(key="verbose", _type=bool, default=False))
-    settings.add(Setting(key="foo", _type=str))
+    settings.add(Setting(key="loud", _type=bool, default=True))
+    settings.add(Setting(key="foo.bar", _type=str))
     configs = ConfigRegistry(setting_registry=settings)
 
     with patch('omniconf.backends.argparse.ARGPARSE_SOURCE', MIXED_ARGS):
@@ -111,4 +113,5 @@ def test_mixed_flags_and_settings():
         configs.load([backend])
 
         nose.tools.assert_true(configs.get("verbose"))
-        nose.tools.assert_equal(configs.get("foo"), "bar")
+        nose.tools.assert_false(configs.get("loud"))
+        nose.tools.assert_equal(configs.get("foo.bar"), "baz")

--- a/omniconf/tests/backends/test_generic.py
+++ b/omniconf/tests/backends/test_generic.py
@@ -34,7 +34,7 @@ def test_config_backend_get_values_no_settings():
     nose.tools.assert_equal(ConfigBackend().get_values([]), [])
 
 
-def test_config_backend_missing_value():
+def test_config_backend_get_values_missing_value():
     backend = ConfigBackend(conf={})
     setting = Setting("foo", _type=str)
     values = backend.get_values([setting])

--- a/omniconf/tests/backends/test_generic.py
+++ b/omniconf/tests/backends/test_generic.py
@@ -17,6 +17,7 @@
 # <http://www.gnu.org/licenses/>.
 
 from omniconf.backends.generic import ConfigBackend
+from omniconf.setting import Setting
 import nose.tools
 
 
@@ -27,3 +28,21 @@ def test_config_backend_autoconfigure():
 
 def test_config_backend_autodetect_settings():
     nose.tools.assert_equal(ConfigBackend.autodetect_settings(None), ())
+
+
+def test_config_backend_get_values_no_settings():
+    nose.tools.assert_equal(ConfigBackend().get_values([]), [])
+
+
+def test_config_backend_missing_value():
+    backend = ConfigBackend(conf={})
+    setting = Setting("foo", _type=str)
+    values = backend.get_values([setting])
+    nose.tools.assert_equal(values, [])
+
+
+def test_config_backend_get_values():
+    backend = ConfigBackend(conf={"foo": "bar"})
+    setting = Setting("foo", _type=str)
+    values = backend.get_values([setting])
+    nose.tools.assert_equal(values, [(setting, "bar")])

--- a/omniconf/tests/test_config.py
+++ b/omniconf/tests/test_config.py
@@ -110,15 +110,18 @@ class TestConfigRegistry(unittest.TestCase):
 
     def test_config_registry_load_with_unavailable_values(self):
         mock_backend = Mock(autospec=ConfigBackend)
-        mock_backend.get_values.side_effect = \
-            UnconfiguredSettingError("No value")
+        mock_backend.get_values.return_value = []
 
         with self.assertRaises(UnconfiguredSettingError):
             self.config_registry.load([mock_backend])
 
     def test_config_registry_load_value_error(self):
+        int_setting = Setting(key="foo", _type=int)
+        self.setting_registry.add(int_setting)
+
         mock_backend = Mock(autospec=ConfigBackend)
-        mock_backend.get_values.side_effect = ValueError("Invalid value")
+        mock_backend.get_values.return_value = [
+            (int_setting, "bar")]
 
         with self.assertRaises(ValueError):
             self.config_registry.load([mock_backend])

--- a/omniconf/tests/test_config.py
+++ b/omniconf/tests/test_config.py
@@ -17,12 +17,13 @@
 # <http://www.gnu.org/licenses/>.
 
 import unittest
+from omniconf.backends.generic import ConfigBackend
 from omniconf.config import ConfigRegistry, config, DEFAULT_REGISTRY, \
                             SETTING_REGISTRY
 from omniconf.exceptions import UnknownSettingError, \
                                 UnconfiguredSettingError
 from omniconf.setting import SettingRegistry, Setting
-from mock import Mock, call
+from mock import Mock
 import nose.tools
 
 
@@ -86,18 +87,19 @@ class TestConfigRegistry(unittest.TestCase):
             self.config_registry.get("key")
 
     def test_config_registry_load(self):
-        mock_backend = Mock()
-        mock_backend.get_value.return_value = "value"
+        mock_backend = Mock(autospec=ConfigBackend)
+        mock_backend.get_values.return_value = [(s, "value")
+                                                for s in self.test_settings]
         self.config_registry.load([mock_backend])
 
-        mock_backend.get_value.assert_has_calls(
-            [call(setting) for setting in self.test_settings], any_order=True)
+        mock_backend.get_values.assert_called_once_with(self.test_settings)
         self.assertEqual(self.config_registry.get("key"), "value")
         self.assertEqual(self.config_registry.get("default"), "value")
 
     def test_config_registry_load_with_previous_values(self):
-        mock_backend = Mock()
-        mock_backend.get_value.return_value = "value"
+        mock_backend = Mock(autospec=ConfigBackend)
+        mock_backend.get_values.return_value = [(s, "value")
+                                                for s in self.test_settings]
         self.config_registry.set("key", "other")
         self.config_registry.set("default", "other")
 
@@ -107,15 +109,16 @@ class TestConfigRegistry(unittest.TestCase):
         self.assertEqual(self.config_registry.get("default"), "other")
 
     def test_config_registry_load_with_unavailable_values(self):
-        mock_backend = Mock()
-        mock_backend.get_value.side_effect = KeyError("No value")
+        mock_backend = Mock(autospec=ConfigBackend)
+        mock_backend.get_values.side_effect = \
+            UnconfiguredSettingError("No value")
 
         with self.assertRaises(UnconfiguredSettingError):
             self.config_registry.load([mock_backend])
 
     def test_config_registry_load_value_error(self):
-        mock_backend = Mock()
-        mock_backend.get_value.side_effect = ValueError("Invalid value")
+        mock_backend = Mock(autospec=ConfigBackend)
+        mock_backend.get_values.side_effect = ValueError("Invalid value")
 
         with self.assertRaises(ValueError):
             self.config_registry.load([mock_backend])

--- a/omniconf/tests/test_loader.py
+++ b/omniconf/tests/test_loader.py
@@ -23,10 +23,12 @@ from mock import Mock, patch
 import unittest
 
 autodetection_mock = Mock(autospec=ConfigBackend)
+autodetection_mock().get_values.return_value = []
 
 autoconfigure_mock = Mock(autospec=ConfigBackend)
+autoconfigure_mock().get_values.return_value = []
 autoconfigure_mock.autodetect_settings.return_value = [
-    Setting("omniconf.foo", _type=str, required=True)]
+    Setting("omniconf.foo", _type=str)]
 autoconfigure_mock.autoconfigure.return_value = autoconfigure_mock
 
 


### PR DESCRIPTION
An bug could occur that when using cli flags and cli options, a flag might eat a option. For instance: `program --verbose --foo bar` might eat the `--foo` option. This is because we parse cli options one at a time.

The solution for this problem is parsing all cli options at once, so that Argparse can handle the flag and options correctly.