### PR TITLE
Python 3.8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
   - pypy        # Python 2.7 compatible
   - pypy3.5     # Python 3.5 compatible
   - pypy3       # Python 3.6 compatible

--- a/omniconf/types.py
+++ b/omniconf/types.py
@@ -16,7 +16,10 @@
 # License along with this library. If not, see
 # <http://www.gnu.org/licenses/>.
 
-import collections
+try:
+   from collections import abc
+except ImportError:  # pragma: nocover
+   import collections as abc
 
 try:
     string_types = (str, unicode)
@@ -24,7 +27,7 @@ except NameError:  # pragma: nocover
     string_types = (str, bytes)
 
 
-class SeparatorSequence(collections.Sequence):
+class SeparatorSequence(abc.Sequence):
     """
     Splits the given string using the given separator, and provides a
     the result with a read-only Sequence interface.
@@ -63,7 +66,7 @@ def separator_sequence(separator):
     and can be used as one would normally use a (read-only) tuple or list.
     """
     def factory(value):
-        if isinstance(value, collections.Sequence) and \
+        if isinstance(value, abc.Sequence) and \
                 not isinstance(value, string_types):
             return value
         return SeparatorSequence(value, separator)

--- a/omniconf/types.py
+++ b/omniconf/types.py
@@ -17,9 +17,9 @@
 # <http://www.gnu.org/licenses/>.
 
 try:
-   from collections import abc
+    from collections import abc
 except ImportError:  # pragma: nocover
-   import collections as abc
+    import collections as abc
 
 try:
     string_types = (str, unicode)

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ classifier =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: Jython
     Programming Language :: Python :: Implementation :: PyPy

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = setup,py27,py33,py34,py35,py36,pypy,jython,coverage,sphinx
+envlist = setup,py27,py34,py35,py36,py37,py38,pypy,jython,coverage,sphinx
 
 [testenv]
 deps =


### PR DESCRIPTION
Remove DeprecationWarnings about collections.abc and add Python 3.8 to test suite.